### PR TITLE
Resolving naming issue

### DIFF
--- a/src/main/java/io/bpoole6/accumulator/controller/MetricsController.java
+++ b/src/main/java/io/bpoole6/accumulator/controller/MetricsController.java
@@ -51,7 +51,7 @@ public class MetricsController implements MetricsControllerInterface{
 
 
   public ResponseEntity<Object> resetMetricGroup(@PathVariable("metricGroup") String metricGroup) throws InterruptedException {
-    Group group = this.metricsAccumulatorConfiguration.getMetricGroups().get(metricGroup.toLowerCase());
+    Group group = this.metricsAccumulatorConfiguration.getMetricGroups().get(metricGroup);
 
     if( metricService.resetMetricGroup(group)) {
       return new ResponseEntity<>("Metrics reset for %s".formatted(metricGroup), HttpStatus.OK);
@@ -65,7 +65,7 @@ public class MetricsController implements MetricsControllerInterface{
   public ResponseEntity<String> receiveMetrics(@PathVariable("metricGroup") String metricGroup, @RequestBody String metrics)
           throws IOException, InterruptedException {
     Optional<Group> contextMetricGroup = getMetricGroupFromSecurityContext();
-    Group group = this.metricsAccumulatorConfiguration.getMetricGroups().get(metricGroup.toLowerCase());
+    Group group = this.metricsAccumulatorConfiguration.getMetricGroups().get(metricGroup);
 
     if (Objects.nonNull(group)) {
       if(contextMetricGroup.isPresent() && !group.equals(contextMetricGroup.get())) {
@@ -80,7 +80,7 @@ public class MetricsController implements MetricsControllerInterface{
 
 
   public ResponseEntity<String> metrics(@PathVariable("metricGroup") String metricName) {
-    Group group = this.metricsAccumulatorConfiguration.getMetricGroups().get(metricName.toLowerCase());
+    Group group = this.metricsAccumulatorConfiguration.getMetricGroups().get(metricName);
     if (Objects.isNull(group)) {
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }

--- a/src/main/java/io/bpoole6/accumulator/controller/MetricsController.java
+++ b/src/main/java/io/bpoole6/accumulator/controller/MetricsController.java
@@ -62,7 +62,7 @@ public class MetricsController implements MetricsControllerInterface{
 
 
 
-  public ResponseEntity<String> receiveMetrics(@PathVariable("metricGroup") String metricGroup, @RequestBody String metrics)
+  public ResponseEntity<String> updateMetrics(@PathVariable("metricGroup") String metricGroup, @RequestBody String metrics)
           throws IOException, InterruptedException {
     Optional<Group> contextMetricGroup = getMetricGroupFromSecurityContext();
     Group group = this.metricsAccumulatorConfiguration.getMetricGroups().get(metricGroup);

--- a/src/main/java/io/bpoole6/accumulator/controller/MetricsControllerInterface.java
+++ b/src/main/java/io/bpoole6/accumulator/controller/MetricsControllerInterface.java
@@ -63,7 +63,7 @@ interface MetricsControllerInterface {
           @ApiResponse(responseCode = "401", description = "You authenticated but apiKey doesn't correspond to metric Group supplied"),
   })
   @PostMapping(value = "update/{metricGroup}", consumes = {"text/plain"})
-  ResponseEntity<String> receiveMetrics(@PathVariable("metricGroup") String metricGroup, @RequestBody String metrics)
+  ResponseEntity<String> updateMetrics(@PathVariable("metricGroup") String metricGroup, @RequestBody String metrics)
           throws IOException, InterruptedException;
 
   @Operation(

--- a/src/main/java/io/bpoole6/accumulator/service/MetricsAccumulatorConfiguration.java
+++ b/src/main/java/io/bpoole6/accumulator/service/MetricsAccumulatorConfiguration.java
@@ -3,6 +3,7 @@ package io.bpoole6.accumulator.service;
 import io.bpoole6.accumulator.service.metricgroup.Global;
 import io.bpoole6.accumulator.service.metricgroup.Group;
 import io.bpoole6.accumulator.service.metricgroup.Root;
+import java.util.function.Function;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
@@ -54,7 +55,8 @@ public class MetricsAccumulatorConfiguration {
         String content = Files.readString(file.toPath());
         Root root = yaml.loadAs(content, Root.class);
         validateConfigs(root);
-        this.metricGroups = root.getMetricGroups();
+        this.metricGroups = root.getMetricGroups().values().stream().collect(Collectors.toMap(i->i.getName(),
+            Function.identity()));
         this.hostAddress = root.getGlobal().getHostAddress();
         this.metricGroupByApiKey = metricGroups.values().stream().collect(Collectors.toMap(Group::getApiKey, g -> g));
         this.global = root.getGlobal();

--- a/src/test/java/io/bpoole6/accumulator/TestUtils.java
+++ b/src/test/java/io/bpoole6/accumulator/TestUtils.java
@@ -8,7 +8,7 @@ public class TestUtils {
 
 	public static Path createMetricsFile() throws IOException {
 		Path path = Files.createTempFile("config",".yml");
-		Files.writeString(path,metricsFile("test"));
+		Files.writeString(path,metricsFile("test-Metrics"));
 		return path;
 	}
   public static String metricsFile(String name){


### PR DESCRIPTION
The key name was being used as the metric group name. This caused a problem where the configuration metricGroup key name didn't match the name property of the metric. This change should make it where the metric group name used through out the code base is the `Configuration.metricGroups.<key>.name` property.

Also updated the update method name in the controller.